### PR TITLE
Fix unintended u-turn possibility.

### DIFF
--- a/src/app/models/snake.model.ts
+++ b/src/app/models/snake.model.ts
@@ -11,6 +11,7 @@ export class Snake {
     private headIndex: number = 0;
 
     direction: Direction = Direction.RIGHT;
+    facing: Direction = this.direction;
     body: Cell[] = INITIAL_SNAKE_COORDINATES;
   
     containsCell(cell: Cell): boolean {
@@ -22,6 +23,7 @@ export class Snake {
     move() {
         this.body = this.body.map((cell: Cell, index: number) => {
             if (index === this.headIndex) {
+                this.facing = this.direction;
                 return cell.getNeighbour(this.direction);
             }
             

--- a/src/app/services/snake.service.ts
+++ b/src/app/services/snake.service.ts
@@ -7,7 +7,7 @@ import { Direction } from "../enums/direction.enum";
 })
 export class SnakeService {
     changeDirection(snake: Snake, direction: Direction) {
-        const canChangeDirection = this.canChangeDirection(direction, snake.direction);
+        const canChangeDirection = this.canChangeDirection(direction, snake.facing);
         if (canChangeDirection) {
             snake.direction = direction;
         }


### PR DESCRIPTION
It was possible to have the snake switch the direction it is moving in by tapping to turn left of where it's facing (or right) twice in between movement steps.

Now we keep which direction the snake is facing and this is no longer possible.